### PR TITLE
lazy-init _validator, this way dependency order won`t matter

### DIFF
--- a/common.blocks/form-field/_has-validate/form-field_has-validate.browser.js
+++ b/common.blocks/form-field/_has-validate/form-field_has-validate.browser.js
@@ -14,11 +14,13 @@ FormField.decl({ block : this.name, modName : 'has-validate', modVal : true }, /
         'js' : {
             'inited' : function() {
                 this._status = null;
-                this._validator = Validation.create();
-
                 this.on('blur', this.validate);
             }
         }
+    },
+
+    getValidator : function() {
+        return this._validator || (this._validator = Validation.create());
     },
 
     /**
@@ -27,7 +29,7 @@ FormField.decl({ block : this.name, modName : 'has-validate', modVal : true }, /
      * @returns {Boolean}
      */
     validate : function() {
-        this._status = this._validator.check(this.getVal());
+        this._status = this.getValidator().check(this.getVal());
         this._updateStatus();
 
         return this._status;
@@ -39,7 +41,7 @@ FormField.decl({ block : this.name, modName : 'has-validate', modVal : true }, /
         this.getControl().toggleMod('invalid', true, Boolean(this._status));
 
         // Use it in your levels
-        //this.hasMod('message') && this.setMessageVal(this._status);
+        // this.hasMod('message') && this.setMessageVal(this._status);
     }
 });
 

--- a/common.blocks/form-field/_required/form-field_required.browser.js
+++ b/common.blocks/form-field/_required/form-field_required.browser.js
@@ -19,7 +19,7 @@ FormField.decl({ modName : 'required', modVal : true }, /** @lends form-field.pr
             'inited' : function() {
                 this.__base.apply(this, arguments);
 
-                this._validator.push(validation_required(this.params.message));
+                this.getValidator().push(validation_required(this.params.message));
             }
         }
     }

--- a/common.blocks/form-field/_validate/form-field_validate_card.browser.js
+++ b/common.blocks/form-field/_validate/form-field_validate_card.browser.js
@@ -19,7 +19,7 @@ FormField.decl({ modName : 'validate', modVal : 'card' }, /** @lends form-field.
             'inited' : function() {
                 this.__base.apply(this, arguments);
 
-                this._validator.push(validate_card(this.params.message));
+                this.getValidator().push(validate_card(this.params.message));
             }
         }
     }


### PR DESCRIPTION
`js/inited` of `has-validate : true` is not necessarily called before `required : true` and `validate : card`, so `this._validate` may be undefined. This commit is fixing this issue.