### PR TITLE
Implement getControl for input_type_hidden

### DIFF
--- a/common.blocks/form-field/_type/form-field_type_hidden.browser.js
+++ b/common.blocks/form-field/_type/form-field_type_hidden.browser.js
@@ -3,12 +3,23 @@ function(provide, FormField) {
 
 provide(FormField.decl({ modName : 'type', modVal : 'hidden' }, {
 
+    onSetMod : {
+        'disabled' : function(modName, modVal) {
+            this.getControl().prop('disabled', modVal);
+        }
+    },
+
     setVal : function(val) {
         this.params.value = val;
+        this.getControl().val(val);
     },
 
     getVal : function() {
         return this.params.value || '';
+    },
+
+    getControl : function() {
+        return this._control || (this._control = this.domElem.find('input'));
     }
 
 }));


### PR DESCRIPTION
`getControl` returns `input` DOM-element. This also prevents unnecessary warnings from `form-field` like `control is required`.