### PR TITLE
fix mix rewrrite bug

### DIFF
--- a/common.blocks/message/_type/message_type_text.bemhtml.js
+++ b/common.blocks/message/_type/message_type_text.bemhtml.js
@@ -1,3 +1,3 @@
 block('message').mod('type', 'text')(
-    mix()({ elem : 'control' })
+    addMix()({ elem : 'control' })
 );


### PR DESCRIPTION
We have a bug while messge block has type: text. It rewrites form-field mix.